### PR TITLE
Vorschlag: googlemaps → openstreetmap

### DIFF
--- a/components/Entry.vue
+++ b/components/Entry.vue
@@ -32,7 +32,7 @@
 		
 		<p class="flex large-gap">
 			
-			<a :href="`https://www.google.de/maps/search/${address}`" target="_blank" class="flex small-gap no-wrap">
+			<a :href="`https://www.openstreetmap.org/search?query=${address}`" target="_blank" class="flex small-gap no-wrap">
 				<MapIcon />{{ address }}
 			</a>
 	


### PR DESCRIPTION
Hier ist ein Vorschlag: OpenStreetMap statt Google Maps nutzen. OSM ist sehr gut in Deutschland, und ich glaube alle Addresses sind findbar. OSM is besser für Datenschutz als Google Maps. Falls nicht gefundendten Addressen, man kann es einfügen.

Ich kann lieder diese nicht probieren, ich kriege “error.response is undefined.  An error occurred while rendering the page. Check developer tools console for details.” im Browser denach `npm run dev`. Aber Ich _nehme_ das diese Patch geht an, 😉

PS: Falls jemand möchtet, ich mache die OpenStreetMap Sticker Programme, und hab viele [Trans OpenStreetMap stickers](https://wiki.openstreetmap.org/wiki/File:2019_v1_OSM_Logo_trans.svg). Schick mal diene address zu [`communication@osmfoundation.org`](mailto:communication@osmfoundation.org?subject=OSM%20Sticker%20request), und ich schick dir was kostenlos. [alle OSM stickers](https://wiki.openstreetmap.org/wiki/OSM_Promotional_Material_Programme#Stickers). Ich bin eine transfem, und bin auf dem OpenStreetMap Foundation Vorstand. 😊
_PPS: Entschuldigung fürs schlechtes deutsch_