### PR TITLE
Ackee tracking fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "website",
-  "version": "0.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -3,12 +3,14 @@ import axios from "axios"
 
 import { goto } from "$app/navigation"
 import { popupWarn } from "$components/popup.svelte"
+import { token } from "./store"
 
 axios.interceptors.response.use((res) => res, (err) => {
 	// Axios interceptor (middleware) to redirect unauthorized requests to login page
 	if (err.response.status === 401 && !window.location.pathname.includes("/login")) {
 		goto("/login");	
 		popupWarn("Bitte melde dich erneut an");
+		token.set("");
 		return;
 	}
 	

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -2,7 +2,6 @@
 	import type { Load } from "@sveltejs/kit"
 	
 	import { get } from "svelte/store"
-	import { browser } from "$app/env"
 	
 	import ackee from "$lib/ackee"
 	import { injectSession } from "$lib/axios"
@@ -26,7 +25,7 @@
 		// also don't track team members
 		let noTrack = ["/manage", "/login"].includes(path) || Boolean(get(token));
 		
-		if (!noTrack && browser) {
+		if (!noTrack) {
 			ackee(path);
 		}
 		

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,8 +1,13 @@
 <script context="module" lang="ts">
+	import type { Load } from "@sveltejs/kit"
+	
+	import { get } from "svelte/store"
+	import { browser } from "$app/env"
+	
 	import ackee from "$lib/ackee"
 	import { injectSession } from "$lib/axios"
 	import { populateConfig } from "$lib/config"
-	import type { Load } from "@sveltejs/kit"
+	import { token } from "$lib/store"
 	
 	let configLoaded = false;
 	
@@ -15,9 +20,15 @@
 			configLoaded = true;
 		}
 		
-		ackee(url.pathname);
-		
 		let path = url.pathname.startsWith("/manage") ? "/manage" : url.pathname;
+		
+		// do not track some paths
+		// also don't track team members
+		let noTrack = ["/manage", "/login"].includes(path) || Boolean(get(token));
+		
+		if (!noTrack && browser) {
+			ackee(path);
+		}
 		
 		return {
 			props: { path }


### PR DESCRIPTION
Some small improvments to how we handle analytics:

* Don't track users with a login token
* Don't track "/login" and "/manage" paths
* Clear login token on expired login